### PR TITLE
fix: patch sidebar target to "bordergrid" that GH AB testing

### DIFF
--- a/source/content-repo.js
+++ b/source/content-repo.js
@@ -176,7 +176,19 @@ export async function loadMoreRepos(resetOffset = false) {
     // Ensure the container exists
     let container = document.querySelector('#similar-repos-container');
     if (!container) {
-        const sidebar = document.querySelector('.Layout-sidebar > div');
+        const sidebar =
+            document.querySelector(
+              'rails-partial[data-partial-name="codeViewRepoRoute.Sidebar"] .BorderGrid'
+            ) ||
+            document.querySelector('.Layout-sidebar > div') ||
+            document.querySelector('.Layout-sidebar') ||
+            document.querySelector('[data-testid="repository-sidebar"]');
+
+        if (!sidebar) {
+            console.warn('💈 SimRepo: no sidebar mount point (new GitHub layout)');
+            return;
+        }
+
         sidebar.insertAdjacentHTML('beforeend', getLoadingContainerHtml());
         setupSettingsListener();
         container = document.querySelector('#similar-repos-container');


### PR DESCRIPTION
# problem context:
Recently, SimRepo has behaved inconsistently for me.
Sometimes it worked, but "most of the time" it did not.

**related issue**: [*SimRepo does not work with certain users `#17`*](https://github.com/Mubelotix/SimRepo/issues/17)

Upon investigation, a pattern was observed:
**SimRepo does work, *all of the time***--but only for some of my user accounts, or when I was signed out from github.

For example, simrepo "does not work" for this current user `evdcush`, but it does for others.

# approach

Whiel debugging with devtools, i noted that the **elem div class name for the sidebar area was totally different** between the working user and non-working user case.

**usual**: `'.Layout-sidebar > div'`

**Github new idea**: `'rails-partial[data-partial-name="codeViewRepoRoute.Sidebar"] .BorderGrid'`

**Screencap of GH's A/B alternative name**:
![](https://github.com/user-attachments/assets/987db1dd-53ab-4a19-8083-40c47dd5be2d)

I observed the new sidebar name in 2 accounts. The new name was not observed in 1 account, nor public, standard logged-out github.

Given this pattern, it is likely **github is conductign an A/B test in prod** on whatever their latest solution/feature is in search of a problem.

this explains why only a few users experience the issue, while it is never observed when logged-out. (This is just a hypothesis; needless to say, GH did not notify about an experiment to my user, nor log any diff to the security log, or anything)


# solution

The "solution" of this branch is simple:
to target both current name and github's fancy for a new name.

this diff was tested out locally from builds on these diffs.
simrepo worked without issue now for both the current default sidebar elem name, as well as the other name.



