### PR TITLE
Fix: update SimRepo container target to latest sidebar layout anchor

### DIFF
--- a/source/content-repo.js
+++ b/source/content-repo.js
@@ -131,6 +131,21 @@ function getErrorContainerHtml(error = "No similar repositories found.") {
     </div>`;
 }
 
+function keepContainerAtBottom(sidebar) {
+    const observer = new MutationObserver(() => {
+        const container = document.querySelector('#similar-repos-container');
+        if (container &&
+            container.parentElement === sidebar &&
+            container !== sidebar.lastElementChild
+        ) {
+            sidebar.appendChild(container);
+        }
+    });
+    observer.observe(sidebar, {
+        childList: true,
+    });
+}
+
 function setupCallback() {
     const viewMoreLink = document.querySelector('#similar-repos-view-more');
     if (viewMoreLink) {
@@ -177,6 +192,12 @@ export async function loadMoreRepos(resetOffset = false) {
     let container = document.querySelector('#similar-repos-container');
     if (!container) {
         const sidebar =
+            // New Github sidebar (2026/07~).
+            document.querySelector(
+                '[data-component="SplitPageLayout.Pane"] ' +
+                '[class*="CodeViewSidebar-module__borderGrid__"]'
+            ) ||
+            // Previous Github sidebar.
             document.querySelector(
               'rails-partial[data-partial-name="codeViewRepoRoute.Sidebar"] .BorderGrid'
             ) ||
@@ -192,6 +213,9 @@ export async function loadMoreRepos(resetOffset = false) {
         sidebar.insertAdjacentHTML('beforeend', getLoadingContainerHtml());
         setupSettingsListener();
         container = document.querySelector('#similar-repos-container');
+        // Github appends sidebar sections asynchronously.
+        // Move SimRepo back to the bottom whenever that happens.
+        keepContainerAtBottom(sidebar);
     }
 
     // Don't fetch if private


### PR DESCRIPTION
I noticed **SimRepo recently stopped showing any container** at the side.

Opening the console, saw the sidebar mount point warning logged by SimRepo.

<details>
  <summary>screencap</summary>

![](https://github.com/user-attachments/assets/755e5b99-8c3c-4df3-8611-240748a46728)

</details>


**Github appears to have updated the repository sidebar layout** again (related: https://github.com/Mubelotix/SimRepo/pull/18).

<details>
  <summary>layout diffs</summary>

**PREVIOUS**:
```rails-partial[data-partial-name="codeViewRepoRoute.Sidebar"]```

**NEW**:
```[data-component="SplitPageLayout.Pane"] [class*="CodeViewSidebar-module__borderGrid__"]```

</details>

This branch **updates the sidebar selector to match the current layout** and keeping the previous selector as a fallback 

It also **keeps the injected "Similar repositories" panel pinned to the bottom** of the sidebar (since github now dynamically reorders sidebar sections after the page loads).

changes were built and tested locally; simrepos returned.