### PR TITLE
SimRepo manifest ver: `0.5.1` --> `0.5.2`  so it builds with the patches made in `873668a`

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/chrome-manifest",
     "name": "SimRepo",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "Shows similar repositories on GitHub",
     "homepage_url": "https://github.com/Mubelotix/SimRepo",
     "manifest_version": 3,


### PR DESCRIPTION
this branch simply bumps the patch number on the package `manifest.json`.

FROM:
`"version": "0.5.1"`
TO:
``"version": "0.5.2"``

**I'm not enteirly shure**, but i believe this version bump is needed to actually trigger a build & release on Mubelotix's SimRepo to get fixed new builds.

i am imitating Mubelotix's actions that were taken after [fix: patch sidebar target to "bordergrid" that GH AB testing- #18](https://github.com/Mubelotix/SimRepo/pull/18), wehre Mubelotix bumped manifest at https://github.com/Mubelotix/SimRepo/commit/104c40d690a9a305dff33c0a5f23f2fac9df4c05

@Mubelotix 

please feel free to close, merge, modify this PR in whatever way is most convenient for you.


---

possibly releated to:
https://github.com/Mubelotix/SimRepo/issues/22

(my own experience is also that simrepo doesn't show/work. except on the machines that i manually installed the patched version.)