### PR TITLE
Fix: update simrepo to target GH's latest sidebar markup 

### DIFF
--- a/source/content-repo.js
+++ b/source/content-repo.js
@@ -146,11 +146,12 @@ function keepContainerAtBottom(sidebar) {
     });
 }
 
+// Convert GitHub counts like "1,234" or "1.2k" to numbers.
 function parseCount(text) {
     const match = text
         .trim()
         .replace(/,/g, '')
-        .match(/^([\d.]+)\s*([kKmM]?)$/);
+        .match(/^(\d+(?:\.\d+)?)\s*([kKmM]?)$/);
 
     if (!match) {
         return null;
@@ -251,18 +252,21 @@ export async function loadMoreRepos(resetOffset = false) {
 
     // Don't fetch if less than 100 stars
     try {
+        // Build the current repository path for the star-count link.
         const repoPath = '/' + window.location.pathname
             .split('/')
             .filter(Boolean)
             .slice(0, 2)
             .join('/');
 
+        // Support both githubs' previous and current star-count markup.
         const starElement =
             document.querySelector('#repo-stars-counter-star') ||
             document.querySelector(
                 `a[href="${repoPath}/stargazers"] strong`
             );
 
+        // Read the old numeric title or the new visible abbreviated count.
         const starsCount = parseCount(
             starElement?.getAttribute('title') ||
             starElement?.textContent ||

--- a/source/content-repo.js
+++ b/source/content-repo.js
@@ -251,11 +251,6 @@ export async function loadMoreRepos(resetOffset = false) {
 
     // Don't fetch if less than 100 stars
     try {
-
-        /*
-        let starSpan = document.querySelector("span[id=\"repo-stars-counter-star\"]");
-        let starsCount = starSpan ? parseInt(starSpan.getAttribute("title").replace(/,/g, '')) : 0;
-        */
         const repoPath = '/' + window.location.pathname
             .split('/')
             .filter(Boolean)
@@ -276,6 +271,11 @@ export async function loadMoreRepos(resetOffset = false) {
 
         if (starsCount === null) {
             console.warn('💈 SimRepo: repository star count not found');
+            // Avoid leaving the panel stuck on "Loading".
+            container.outerHTML = getErrorContainerHtml(
+                "Unable to determine repository star count."
+            );
+            setupSettingsListener();
             return;
         }
 

--- a/source/content-repo.js
+++ b/source/content-repo.js
@@ -146,6 +146,25 @@ function keepContainerAtBottom(sidebar) {
     });
 }
 
+function parseCount(text) {
+    const match = text
+        .trim()
+        .replace(/,/g, '')
+        .match(/^([\d.]+)\s*([kKmM]?)$/);
+
+    if (!match) {
+        return null;
+    }
+
+    const multipliers = {
+        '': 1,
+        k: 1_000,
+        m: 1_000_000,
+    };
+
+    return Number(match[1]) * multipliers[match[2].toLowerCase()];
+}
+
 function setupCallback() {
     const viewMoreLink = document.querySelector('#similar-repos-view-more');
     if (viewMoreLink) {
@@ -232,8 +251,35 @@ export async function loadMoreRepos(resetOffset = false) {
 
     // Don't fetch if less than 100 stars
     try {
+
+        /*
         let starSpan = document.querySelector("span[id=\"repo-stars-counter-star\"]");
         let starsCount = starSpan ? parseInt(starSpan.getAttribute("title").replace(/,/g, '')) : 0;
+        */
+        const repoPath = '/' + window.location.pathname
+            .split('/')
+            .filter(Boolean)
+            .slice(0, 2)
+            .join('/');
+
+        const starElement =
+            document.querySelector('#repo-stars-counter-star') ||
+            document.querySelector(
+                `a[href="${repoPath}/stargazers"] strong`
+            );
+
+        const starsCount = parseCount(
+            starElement?.getAttribute('title') ||
+            starElement?.textContent ||
+            ''
+        );
+
+        if (starsCount === null) {
+            console.warn('💈 SimRepo: repository star count not found');
+            return;
+        }
+
+
         if (starsCount < 100) {
             if (options.similarShowUnavailable) {
                 container.outerHTML = getErrorContainerHtml("Unavailable for repositories with less than 100 stars.");


### PR DESCRIPTION
**GH changed the repo sidebar markup**, so SimRepo couldn't find the star count.
The missing element was treated as `0` (stars), which caused 100+ star repos to incorrectly show:

> Unavailable for repositories with less than 100 stars.


FIX:
This branch updates the star-count lookup to support GH's previous and current markup. it also adds parsing for formatted counts such as `1,234` and `1.2k`.

If the star count still can't be found, SimRepo now shows a clear error instead of binning it as a zero-star repo.


the builds from these diffs were tested on:
- CHROME: `Version 150.0.7871.181 (Official Build, ungoogled-chromium) (64-bit)`
- FF: `Package: librewolf Version: 152.0.5-1`

<details>
  <summary>Screencaps</summary>

chromium:
![](https://github.com/user-attachments/assets/a88f7522-ee6d-4e4d-88a9-d1920a11ffbd)

firefox:
![](https://github.com/user-attachments/assets/ee7f53f5-2a06-4dca-a7a3-5640349c39c9)

</details>


the builds are available for testing/experimentation here 👇🏻
<details>
  <summary>simrepo FF and chromium extension builds from 439b057:</summary>

[chrome.zip](https://github.com/user-attachments/files/30631056/chrome.zip)
[firefox.zip](https://github.com/user-attachments/files/30631057/firefox.zip)

</details>



